### PR TITLE
Add FunctionComponent matcher

### DIFF
--- a/src/componentReader.js
+++ b/src/componentReader.js
@@ -52,7 +52,7 @@ function findComponentName(text, fileName) {
 }
 
 function findPropsInterface(text, fileName) {
-  const interfaceNameRegExp = /React.(Component|PureComponent|StatelessComponent)<(.*?)(>|,)/g;
+  const interfaceNameRegExp = /React.(Component|PureComponent|StatelessComponent|FunctionComponent)<(.*?)(>|,)/g;
   const interfaceNameMatch = interfaceNameRegExp.exec(text);
 
   if (interfaceNameMatch) {


### PR DESCRIPTION
I'd like to use snappify in a hook-based environment where FunctionComponents are key. Unfortunately there is yet no matcher for those. I propose change to also catch FunctionComponents.

TBD: Should `SFC`s also be supported?